### PR TITLE
Optionally verify the checksum of the downloaded dependency-tree-diff.jar

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,6 +196,53 @@ jobs:
           path: ${{ steps.dependency-diff-sha.outputs.file-diff }}
           if-no-files-found: error
 
+  test-job-with-checksum:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+    name: Test checksum verification on ${{ matrix.os }}
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version-file: .java-version
+
+      - uses: gradle/actions/setup-gradle@v6
+
+      - id: dependency-diff-invalid-checksum
+        uses: ./
+        continue-on-error: true
+        with:
+          configuration: runtimeClasspath
+          build-root-directory: testproject
+          project: ""
+          lib-version: "1.2.1"
+          lib-checksum: "0000000000000000000000000000000000000000000000000000000000000000"
+
+      - name: Assert invalid checksum fails the action
+        if: steps.dependency-diff-invalid-checksum.outcome != 'failure'
+        run: |
+          echo "::error::Expected the action to fail on checksum mismatch, but it succeeded"
+          exit 1
+        shell: bash
+
+      - id: dependency-diff
+        uses: ./
+        with:
+          configuration: runtimeClasspath
+          build-root-directory: testproject
+          project: ""
+          lib-version: "1.2.1"
+          lib-checksum: "f6c84d5ce8beb3277103fb8235071dd8bc69a7cde75239f636a7c8293ff0c865"
+          debug: true
+
   test-on-different-os:
     strategy:
       fail-fast: false

--- a/Readme.md
+++ b/Readme.md
@@ -67,6 +67,7 @@ All inputs with their default values:
         base-ref: ''
         additional-gradle-arguments: ''
         lib-version: 'latest'
+        lib-checksum: ''
 ```
 
 - **`configuration`** - Selected Gradle configuration, passed to `./gradlew dependencies --configuration xxx`.
@@ -83,6 +84,10 @@ When left empty (the default) the action falls back to `github.base_ref`, i.e. t
 See [Stacked pull requests](#stacked-pull-requests).
 - **`additional-gradle-arguments`** - Additional arguments passed to internal Gradle invocation. Example: `"--no-configuration-cache"` or `"--stacktrace"`  
 - **`lib-version`** - Overrides [dependency-tree-diff](https://github.com/JakeWharton/dependency-tree-diff) dependency version. Example: `"1.2.1"`, `"1.1.0"`, `"latest"`
+- **`lib-checksum`** - Expected SHA-256 checksum of the downloaded `dependency-tree-diff.jar`. 
+When set, the action fails if the downloaded file doesn't match. 
+Only makes sense in combination with a pinned `lib-version`. 
+Example: `lib-version: '1.2.1'` + `lib-checksum: 'f6c84d5ce8beb3277103fb8235071dd8bc69a7cde75239f636a7c8293ff0c865'`
 
 ### Stacked pull requests
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'Dependency diff library version'
     required: true
     default: 'latest'
+  lib-checksum:
+    description: 'Expected SHA-256 checksum of the downloaded `dependency-tree-diff.jar`. When set, the action fails if the downloaded file does not match. Only makes sense when `lib-version` is pinned'
+    required: false
+    default: ''
   additional-gradle-arguments:
     description: 'Additional arguments passed to gradle commands'
     required: false
@@ -56,6 +60,7 @@ runs:
         INPUT_BASEREF: ${{ inputs.base-ref || github.base_ref }}
         INPUT_BUILD_ROOT_DIR: ${{ inputs.build-root-directory }}
         INPUT_VERSION: ${{ inputs.lib-version }}
+        INPUT_CHECKSUM: ${{ inputs.lib-checksum }}
         INPUT_ADDITIONAL_GRADLE_ARGUMENTS: ${{ inputs.additional-gradle-arguments }}
         INPUT_DEBUG: ${{ inputs.debug }}
         GITHUB_TOKEN: ${{ github.token }}
@@ -70,6 +75,7 @@ runs:
         INPUT_BASEREF: ${{ inputs.base-ref || github.base_ref }}
         INPUT_BUILD_ROOT_DIR: ${{ inputs.build-root-directory }}
         INPUT_VERSION: ${{ inputs.lib-version }}
+        INPUT_CHECKSUM: ${{ inputs.lib-checksum }}
         INPUT_ADDITIONAL_GRADLE_ARGUMENTS: ${{ inputs.additional-gradle-arguments }}
         INPUT_DEBUG: ${{ inputs.debug }}
         GITHUB_TOKEN: ${{ github.token }}

--- a/entrypoint.ps1
+++ b/entrypoint.ps1
@@ -4,6 +4,7 @@ param(
     [string]$InputBaseRef = $env:INPUT_BASEREF,
     [string]$InputBuildRootDir = $env:INPUT_BUILD_ROOT_DIR,
     [string]$InputVersion = $env:INPUT_VERSION,
+    [string]$InputChecksum = $env:INPUT_CHECKSUM,
     [string]$InputAdditionalGradleArguments = $env:INPUT_ADDITIONAL_GRADLE_ARGUMENTS,
     [string]$InputDebug = $env:INPUT_DEBUG,
     [string]$GithubToken = $env:GITHUB_TOKEN
@@ -29,6 +30,15 @@ if ($InputVersion -eq "latest") {
 } else {
     $downloadUrl = "https://github.com/JakeWharton/dependency-tree-diff/releases/download/$InputVersion/dependency-tree-diff.jar"
     Invoke-WebRequest -Uri $downloadUrl -Headers $headers -OutFile "dependency-tree-diff.jar"
+}
+
+if (-not [string]::IsNullOrWhiteSpace($InputChecksum)) {
+    $expectedChecksum = $InputChecksum.Trim()
+    $actualChecksum = (Get-FileHash -Path "dependency-tree-diff.jar" -Algorithm SHA256).Hash
+    if ($actualChecksum -ne $expectedChecksum) {
+        Write-Host "::error::Checksum verification of dependency-tree-diff.jar failed. Expected: $expectedChecksum, actual: $actualChecksum"
+        exit 1
+    }
 }
 
 if ($InputProject -eq ":") {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,15 @@ else
   curl -H "Authorization: Bearer $GITHUB_TOKEN" -L -s -o dependency-tree-diff.jar "https://github.com/JakeWharton/dependency-tree-diff/releases/download/$INPUT_VERSION/dependency-tree-diff.jar"
 fi
 
+if [ -n "$INPUT_CHECKSUM" ]; then
+  expected_checksum=$(echo "$INPUT_CHECKSUM" | tr '[:upper:]' '[:lower:]')
+  actual_checksum=$(shasum -a 256 dependency-tree-diff.jar | cut -d ' ' -f 1)
+  if [ "$actual_checksum" != "$expected_checksum" ]; then
+    echo "::error::Checksum verification of dependency-tree-diff.jar failed. Expected: $expected_checksum, actual: $actual_checksum"
+    exit 1
+  fi
+fi
+
 if [ "$INPUT_PROJECT" == ":" ]; then
   INPUT_PROJECT=""
 fi


### PR DESCRIPTION
Closes #249

Adds an optional `lib-checksum` input holding the expected SHA-256 of the downloaded `dependency-tree-diff.jar`. When set, the action fails before running anything if the downloaded file doesn't match; when left empty (the default) nothing changes.

- Verification implemented in both `entrypoint.sh` (via `shasum -a 256`, available on both Linux and macOS runners) and `entrypoint.ps1` (via `Get-FileHash`). Comparison is case-insensitive in both.
- New CI job runs on ubuntu + windows covering both scripts, and asserts both directions: a wrong checksum fails the action (cheap - it exits before any Gradle work), and the correct checksum for the pinned `1.2.1` release passes end to end.
- Documented in the Readme, including the real `1.2.1` checksum as an example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)